### PR TITLE
Rollback to 6.7.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,11 @@ WORKDIR ${PLUGIN_DOWNLOAD_LOCATION}
 # - http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/
 # - https://sonarsource.bintray.com/Distribution/
 # - https://github.com/SonarQubeCommunity/
+#RUN wget https://sonarsource.bintray.com/Distribution/sonar-java-plugin/sonar-java-plugin-4.0.jar
 RUN wget https://github.com/SonarSource/sonar-auth-bitbucket/releases/download/1.0/sonar-auth-bitbucket-plugin-1.0.jar
-RUN wget https://github.com/spotbugs/sonar-findbugs/releases/download/3.7.0/sonar-findbugs-plugin-3.7.0.jar
-RUN wget https://github.com/SonarQubeCommunity/sonar-pmd/releases/download/2.6/sonar-pmd-plugin-2.6.jar
-RUN wget https://github.com/checkstyle/sonar-checkstyle/releases/download/4.11/checkstyle-sonar-plugin-4.11.jar
+#RUN wget https://github.com/spotbugs/sonar-findbugs/releases/download/3.7.0/sonar-findbugs-plugin-3.7.0.jar
+#RUN wget https://github.com/SonarQubeCommunity/sonar-pmd/releases/download/2.6/sonar-pmd-plugin-2.6.jar
+#RUN wget https://github.com/checkstyle/sonar-checkstyle/releases/download/4.11/checkstyle-sonar-plugin-4.11.jar
 RUN wget https://dl.bintray.com/fundacionjala/enforce/apex-plugin-1.0b219.jar
 
 COPY docker-entrypoint.sh /opt/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sonarqube
+FROM sonarqube:6.7.5
 MAINTAINER Angel Soliño "angel@nuvolar.eu"
 
 # create plugin download location; so we can copy them later when SonarQube is started

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-sonarqube
 
-Docker image based on default [SonarQube](https://hub.docker.com/_/sonarqube/) with manually installed plugins. 
+Docker image based on default [SonarQube 6.7.5](https://hub.docker.com/_/sonarqube/) with manually installed plugins. 
 The default provided plugins are kept and some extra plugins are manually downloaded.
 
 To add/remove plugins modify the Dockerfile and build your own version.


### PR DESCRIPTION
As current apex plugin is not compatible with 7.x, go back to 6.7.5 until this https://github.com/fundacionjala/enforce-sonarqube-plugin/issues/131 is solved.